### PR TITLE
Pass viewbox to search for location-biased results

### DIFF
--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,4 +1,9 @@
 {
+  "2.4.4": {
+    "content": [
+      "• Search results now prioritize locations near your current map view"
+    ]
+  },
   "2.4.3": {
     "content": [
       "• Fixed 360° FOV rendering - devices with full circle coverage now render as complete rings instead of having a wedge cut out or being a line",

--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_map/flutter_map.dart' show LatLngBounds;
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -569,8 +570,8 @@ class AppState extends ChangeNotifier {
   }
 
   // ---------- Navigation Methods - Simplified ----------
-  void enterSearchMode(LatLng mapCenter) {
-    _navigationState.enterSearchMode(mapCenter);
+  void enterSearchMode(LatLng mapCenter, {LatLngBounds? viewbox}) {
+    _navigationState.enterSearchMode(mapCenter, viewbox: viewbox);
   }
 
   void cancelNavigation() {

--- a/lib/screens/coordinators/navigation_coordinator.dart
+++ b/lib/screens/coordinators/navigation_coordinator.dart
@@ -138,7 +138,8 @@ class NavigationCoordinator {
         // Enter search mode
         try {
           final center = mapController.mapController.camera.center;
-          appState.enterSearchMode(center);
+          final viewbox = mapController.mapController.camera.visibleBounds;
+          appState.enterSearchMode(center, viewbox: viewbox);
         } catch (e) {
           debugPrint('[NavigationCoordinator] Could not get map center for search: $e');
           // Fallback to default location

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: deflockapp
 description: Map public surveillance infrastructure with OpenStreetMap
 publish_to: "none"
-version: 2.4.3+41   # The thing after the + is the version code, incremented with each release
+version: 2.4.4+42   # The thing after the + is the version code, incremented with each release
 
 environment:
   sdk: ">=3.5.0 <4.0.0"   # oauth2_client 4.x needs Dart 3.5+


### PR DESCRIPTION
Passes the current map viewport to Nominatim as a viewbox parameter when searching. This biases search results toward locations the user is currently viewing.

Fixes #27