### PR TITLE
Update running instructions in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -809,7 +809,8 @@ cd ios && pod install
 ### Running
 ```bash
 flutter pub get
-flutter run
+./gen_icons_splashes.sh
+flutter run --dart-define=OSM_PROD_CLIENT_ID=[your OAuth2 client ID]
 ```
 
 ### Testing


### PR DESCRIPTION
- Added missing step (run gen_icons_splashes.sh) required to run the application for the first time
- Updated the run command to include the OSM_PROD_CLIENT_ID to the environment.