### PR TITLE
Fix map jitter/wiggle when touching at low zoom

### DIFF
--- a/lib/widgets/map/gps_controller.dart
+++ b/lib/widgets/map/gps_controller.dart
@@ -32,6 +32,7 @@ class GpsController {
   List<OsmNode> Function()? _getNearbyNodes;
   List<NodeProfile> Function()? _getEnabledProfiles;
   VoidCallback? _onMapMovedProgrammatically;
+  bool Function()? _isUserInteracting;
 
   /// Get the current GPS location (if available)
   LatLng? get currentLocation => _currentLocation;
@@ -49,6 +50,7 @@ class GpsController {
     required List<OsmNode> Function() getNearbyNodes,
     required List<NodeProfile> Function() getEnabledProfiles,
     VoidCallback? onMapMovedProgrammatically,
+    bool Function()? isUserInteracting,
   }) async {
     debugPrint('[GpsController] Initializing GPS controller');
     
@@ -61,7 +63,8 @@ class GpsController {
     _getNearbyNodes = getNearbyNodes;
     _getEnabledProfiles = getEnabledProfiles;
     _onMapMovedProgrammatically = onMapMovedProgrammatically;
-    
+    _isUserInteracting = isUserInteracting;
+
     // Start location tracking
     await _startLocationTracking();
   }
@@ -235,9 +238,10 @@ class GpsController {
     if (followMeMode == FollowMeMode.off || _mapController == null) {
       return;
     }
-    
     WidgetsBinding.instance.addPostFrameCallback((_) {
       try {
+        if (_isUserInteracting?.call() == true) return;
+
         if (followMeMode == FollowMeMode.follow) {
           // Follow position, preserve rotation
           _mapController!.animateTo(
@@ -352,5 +356,6 @@ class GpsController {
     _getNearbyNodes = null;
     _getEnabledProfiles = null;
     _onMapMovedProgrammatically = null;
+    _isUserInteracting = null;
   }
 }


### PR DESCRIPTION
## Problem

Users report the map "wiggles" under a stationary finger when zoomed out:

> If you put your finger down when zoomed out a lot sometimes the map will wiggle a little under your finger even when ur not moving it

## Root cause

When follow-me mode is active, GPS position updates trigger `animateTo()` animations on the map controller (600ms duration, via `GpsController._handleFollowMeUpdate`). These animations are **not cancelled when the user touches the map**.

Follow-me mode is only disabled via `onUserGesture`, which fires from `onPositionChanged` with `gesture: true` — but that flag only becomes `true` when the user **moves** their finger. A stationary touch-down never sets it. So the animation keeps running under the user's finger, causing the map to visually shift back and forth.

This is:
- **Intermittent** ("sometimes") because the user has to touch during the 600ms animation window
- **Worse at low zoom** because the same geographic GPS displacement covers more screen pixels

Even if we cancel animations on pointer-down, a new GPS update arriving while the finger is still down would restart the animation — so we also need to suppress new follow-me animations while any pointer is on the map.

## Fix

Two coordinated changes:

### `map_view.dart`
- Track active pointer count via a `Listener` widget wrapping `FlutterMap`
- On `onPointerDown`: increment counter, call `_controller.stopAnimations()` to kill any in-progress animation immediately
- On `onPointerUp`/`onPointerCancel`: decrement counter
- Pass `isUserInteracting` callback to `GpsController`

### `gps_controller.dart`
- Accept `isUserInteracting` callback in `initialize()`
- In `_handleFollowMeUpdate`: early-return if user is currently touching the map, preventing new animations from starting

`Listener` is used (not `GestureDetector`) because it doesn't interfere with flutter_map's own gesture recognition — it just observes pointer events passively.

## What doesn't change

- Follow-me mode management (still disabled by `onUserGesture` on drag, as before)
- Constrained node snap-back logic
- Node taps — `Listener` doesn't consume events

## Test plan
- [ ] `flutter test` passes (21/21)
- [ ] `flutter analyze` clean (no new issues)
- [ ] Enable follow-me, zoom out, touch map without moving — no wiggle
- [ ] Follow-me still works normally when not touching
- [ ] Tapping node markers still works with follow-me active

🤖 Generated with [Claude Code](https://claude.com/claude-code)