### PR TITLE
Fix lint warnings after RadioGroup migration

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -813,7 +813,7 @@ class AppState extends ChangeNotifier {
   // ---------- Utility Methods ----------
 
   /// Generate a default changeset comment for a submission
-  /// Handles special case of <Existing tags> profile by using "a" instead
+  /// Handles special case of `<Existing tags>` profile by using "a" instead
   static String generateDefaultChangesetComment({
     required NodeProfile? profile,
     required UploadOperation operation,

--- a/lib/models/node_profile.dart
+++ b/lib/models/node_profile.dart
@@ -266,7 +266,7 @@ class NodeProfile {
   int get hashCode => id.hashCode;
 
   /// Create a temporary empty profile for editing existing nodes
-  /// Used as the default "<Existing tags>" option when editing nodes
+  /// Used as the default `<Existing tags>` option when editing nodes
   /// All existing tags will flow through as additionalExistingTags
   static NodeProfile createExistingTagsProfile(OsmNode node) {
     // Calculate FOV from existing direction ranges if applicable

--- a/lib/services/deflock_tile_provider.dart
+++ b/lib/services/deflock_tile_provider.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter_map/flutter_map.dart';

--- a/lib/services/distance_service.dart
+++ b/lib/services/distance_service.dart
@@ -8,7 +8,6 @@ class DistanceService {
   // Conversion constants
   static const double _metersToFeet = 3.28084;
   static const double _metersToMiles = 0.000621371;
-  static const double _kmToMiles = 0.621371;
 
   /// Format distance for display based on unit preference
   /// 

--- a/lib/services/map_data_submodules/nodes_from_osm_api.dart
+++ b/lib/services/map_data_submodules/nodes_from_osm_api.dart
@@ -7,7 +7,6 @@ import 'package:xml/xml.dart';
 import '../../models/node_profile.dart';
 import '../../models/osm_node.dart';
 import '../../app_state.dart';
-import '../network_status.dart';
 
 /// Fetches surveillance nodes from the direct OSM API using bbox query.
 /// This is a fallback for when Overpass is not available (e.g., sandbox mode).

--- a/lib/services/tile_preview_service.dart
+++ b/lib/services/tile_preview_service.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 

--- a/lib/services/uploader.dart
+++ b/lib/services/uploader.dart
@@ -54,23 +54,6 @@ class Uploader {
         return UploadResult.failure(errorMessage: errorMsg);
       }
       
-      // Generate changeset XML
-      String action;
-      switch (p.operation) {
-        case UploadOperation.create:
-          action = 'Add';
-          break;
-        case UploadOperation.modify:
-          action = 'Update';
-          break;
-        case UploadOperation.delete:
-          action = 'Delete';
-          break;
-        case UploadOperation.extract:
-          action = 'Extract';
-          break;
-      }
-      
       // Use the user's changeset comment, with XML sanitization
       final sanitizedComment = _sanitizeXmlText(p.changesetComment);
       final csXml = '''

--- a/lib/state/session_state.dart
+++ b/lib/state/session_state.dart
@@ -140,16 +140,6 @@ class SessionState extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool _profileMatchesTags(NodeProfile profile, Map<String, String> tags) {
-    // Simple matching: check if all profile tags are present in node tags
-    for (final entry in profile.tags.entries) {
-      if (tags[entry.key] != entry.value) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   /// Calculate additional existing tags for a given profile change
   Map<String, String> _calculateAdditionalExistingTags(NodeProfile? newProfile, OsmNode originalNode) {
     final additionalTags = <String, String>{};
@@ -479,7 +469,7 @@ class SessionState extends ChangeNotifier {
   }
 
   /// Generate a default changeset comment for a submission
-  /// Handles special case of <Existing tags> profile by using "a" instead
+  /// Handles special case of `<Existing tags>` profile by using "a" instead
   String _generateDefaultChangesetComment({
     required NodeProfile? profile,
     required UploadOperation operation,

--- a/lib/widgets/map_view.dart
+++ b/lib/widgets/map_view.dart
@@ -4,15 +4,11 @@ import 'package:flutter_map_animations/flutter_map_animations.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 
-import '../app_state.dart' show AppState, FollowMeMode, UploadMode;
+import '../app_state.dart' show AppState, FollowMeMode;
 import '../services/offline_area_service.dart';
-import '../services/network_status.dart';
 
 import '../models/osm_node.dart';
-import '../models/node_profile.dart';
 import '../models/suspected_location.dart';
-import '../models/tile_provider.dart';
-import '../state/session_state.dart';
 import 'debouncer.dart';
 import 'node_provider_with_cache.dart';
 import 'map/map_overlays.dart';
@@ -170,9 +166,7 @@ class MapViewState extends State<MapView> {
             } catch (_) {
               return [];
             }
-            return mapBounds != null 
-                ? NodeProviderWithCache.instance.getCachedNodesForBounds(mapBounds)
-                : [];
+            return NodeProviderWithCache.instance.getCachedNodesForBounds(mapBounds);
           } catch (e) {
             debugPrint('[MapView] Could not get nearby nodes: $e');
             return [];

--- a/test/services/localization_service_test.dart
+++ b/test/services/localization_service_test.dart
@@ -62,7 +62,6 @@ void main() {
           data = json.decode(content) as Map<String, dynamic>;
         } catch (e) {
           fail('$name is not valid JSON: $e');
-          return; // unreachable, keeps analyzer happy
         }
         expect(
           data['language'],

--- a/test/services/network_status_test.dart
+++ b/test/services/network_status_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/services/network_status.dart';
+import 'package:deflockapp/services/network_status.dart';
 
 void main() {
   group('NetworkStatus', () {


### PR DESCRIPTION
## Summary

Resolves all 17 static analysis issues (10 warnings, 7 infos) introduced by recent changes including the RadioGroup migration.

### Fixes applied

**Unused imports removed (4 files):**
- `lib/services/map_data_submodules/nodes_from_osm_api.dart` — removed unused `network_status.dart` import
- `lib/widgets/map_view.dart` — removed 4 unused imports (`network_status.dart`, `node_profile.dart`, `tile_provider.dart`, `session_state.dart`) and `UploadMode` from the `app_state.dart` show clause

**Unnecessary imports removed (2 files):**
- `lib/services/deflock_tile_provider.dart` — removed `dart:typed_data` (already provided by `package:flutter/foundation.dart`)
- `lib/services/tile_preview_service.dart` — same `dart:typed_data` cleanup

**Unused code removed (3 files):**
- `lib/services/distance_service.dart` — removed unused `_kmToMiles` constant (conversions use `_metersToMiles` instead)
- `lib/services/uploader.dart` — removed unused `action` local variable and its switch statement (changeset comment is now user-provided)
- `lib/state/session_state.dart` — removed unused `_profileMatchesTags` method

**Unnecessary null comparison fixed (1 file):**
- `lib/widgets/map_view.dart:173` — removed redundant `mapBounds != null` check since `visibleBounds` returns non-nullable `LatLngBounds`

**Doc comment angle brackets escaped (3 files):**
- `lib/app_state.dart`, `lib/models/node_profile.dart`, `lib/state/session_state.dart` — wrapped `<Existing tags>` in backticks to prevent interpretation as HTML

**Test fixes (2 files):**
- `test/services/localization_service_test.dart` — removed dead `return` after `fail()` (which always throws)
- `test/services/network_status_test.dart` — replaced relative `../../lib/` import with `package:deflockapp/` import

## Test plan
- [x] `flutter analyze` — 0 issues (was 17)
- [x] `flutter test` — all 32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)