### PR TITLE
Fix null-safety issue with mapBounds in getNearbyNodes

### DIFF
--- a/lib/widgets/map_view.dart
+++ b/lib/widgets/map_view.dart
@@ -160,7 +160,7 @@ class MapViewState extends State<MapView> {
       getNearbyNodes: () {
         if (mounted) {
           try {
-            LatLngBounds? mapBounds;
+            final LatLngBounds mapBounds;
             try {
               mapBounds = _controller.mapController.camera.visibleBounds;
             } catch (_) {


### PR DESCRIPTION
## Summary
- Addresses [review comment on PR #45](https://github.com/FoggedLens/deflock-app/pull/45#discussion_r2784433976): `mapBounds` was declared as `LatLngBounds?` but passed to `getCachedNodesForBounds()` which expects non-null `LatLngBounds`
- Changed from `LatLngBounds? mapBounds;` to `final LatLngBounds mapBounds;` — the inner try-catch already returns `[]` on failure, so after it `mapBounds` is guaranteed initialized and non-null

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — all 32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)