### PR TITLE
Move README roadmap to GitHub Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,43 +103,7 @@ cp lib/keys.dart.example lib/keys.dart
 
 ## Roadmap
 
-### Needed Bugfixes
-- Make submission guide scarier
-- Tile cache trimming? Does fluttermap handle?
-- Filter NSI suggestions based on what has already been typed in
-- NSI sometimes doesn't populate a dropdown, maybe always on the second tag added during an edit session?
-- Clean cache when nodes have been deleted by others
-
-### Current Development
-- Support check_date= tag, update on all edits, quick button to update that only
-- Support source= tag, default to survey, let user pick a different value
-- Add ability to downvote suspected locations which are old enough
-- Turn by turn navigation or at least swipe nav sheet up to see a list
-- Import/Export map providers
-- Update default profiles from the website on launch to capture changes
-
-### Future Features & Wishlist
-- Tap direction slider to enter integer directly
-- Tap pending queue item to edit again before submitting
-- Optional reason message when deleting
-- Update offline area data while browsing?
-- Save named locations to more easily navigate to home or work
-- Offline navigation (pending vector map tiles)
-
-### Maybes
-- Icons/glyphs for profiles
-- "Universal Links" for better handling of profile import when app is not installed
-- Yellow ring for devices missing specific tag details
-- Android Auto / CarPlay
-- "Cache accumulating" offline area? Most recent / most viewed?
-- Grab the full latest database for each profile just like for suspected locations (instead of overpass)?
-- Custom data providers? (OSM/Overpass alternatives)
-- Offer options for extracting nodes which are attached to a way/relation?
-  - Auto extract (how?)
-  - Leave it alone (wrong answer unless user chooses intentionally)
-  - Manual cleanup (cognitive load for users)
-  - Delete the old one (also wrong answer unless user chooses intentionally)
-  - Give multiple of these options??
+See [GitHub Issues](https://github.com/FoggedLens/deflock-app/issues) for the full list of planned features, known bugs, and ideas.
 
 ---
 


### PR DESCRIPTION
## Summary

- Converted all 22 roadmap items from the README into proper GitHub Issues (#55–#76) for better tracking and discussion
- Replaced the 40-line inline roadmap section with a single link to GitHub Issues
- Skipped items already covered by existing issues: check_date/source tags (#32) and icons/glyphs for profiles (#30)

### Issues created

**Needed Bugfixes**
- #55 Make submission guide more prominent/urgent
- #56 Investigate tile cache trimming
- #57 Filter NSI suggestions based on already-typed input
- #58 Fix NSI dropdown not populating on second tag added during edit session
- #59 Clean cache when nodes have been deleted by other OSM users

**Current Development**
- #60 Add ability to downvote suspected locations that are outdated
- #61 Turn-by-turn navigation or swipeable list of nearby devices
- #62 Import/Export map tile providers
- #63 Update default profiles from the website on app launch

**Future Features & Wishlist**
- #64 Allow tapping direction slider to enter an integer directly
- #65 Allow editing pending queue items before submitting
- #66 Optional reason/message when deleting a device
- #67 Update offline area device data while browsing online
- #68 Save named/favorite locations for quick navigation
- #69 Offline navigation (pending vector map tiles)

**Maybes**
- #70 Universal Links for profile import when app is not installed
- #71 Yellow ring indicator for devices missing specific tag details
- #72 Android Auto / CarPlay support
- #73 "Cache accumulating" offline area from browsing history
- #74 Download full database per profile instead of using Overpass
- #75 Custom data providers (OSM/Overpass alternatives)
- #76 Handle nodes attached to ways/relations during editing

## Test plan
- [x] Verify all 22 issues exist on GitHub
- [x] Verify no duplicates with existing issues (#30, #32)
- [ ] Confirm README roadmap section renders correctly with link to Issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)