### PR TITLE
Prompt to remove tag when value is cleared and Done is pressed

### DIFF
--- a/lib/localizations/de.json
+++ b/lib/localizations/de.json
@@ -321,7 +321,9 @@
     "keyHint": "Schlüssel",
     "valueHint": "Wert",
     "atLeastOneTagRequired": "Mindestens ein Tag ist erforderlich",
-    "profileSaved": "Profil \"{}\" gespeichert"
+    "profileSaved": "Profil \"{}\" gespeichert",
+    "removeTagTitle": "Tag entfernen?",
+    "removeTagMessage": "\"{}\" von diesem Profil entfernen?"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "Neues Betreiber-Profil",
@@ -392,7 +394,9 @@
     "existingTagsTitle": "Vorhandene Tags",
     "existingTagsDescription": "Bearbeiten Sie die vorhandenen Tags auf diesem Gerät. Hinzufügen, entfernen oder ändern Sie beliebige Tags:",
     "existingOperator": "<Vorhandener Betreiber>",
-    "existingOperatorTags": "vorhandene Betreiber-Tags"
+    "existingOperatorTags": "vorhandene Betreiber-Tags",
+    "removeTagTitle": "Tag entfernen?",
+    "removeTagMessage": "\"{}\" von diesem Knoten entfernen?"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "Kachel-Typen können während des Herunterladens von Offline-Bereichen nicht geändert werden",

--- a/lib/localizations/en.json
+++ b/lib/localizations/en.json
@@ -358,7 +358,9 @@
     "keyHint": "key",
     "valueHint": "value",
     "atLeastOneTagRequired": "At least one tag is required",
-    "profileSaved": "Profile \"{}\" saved"
+    "profileSaved": "Profile \"{}\" saved",
+    "removeTagTitle": "Remove tag?",
+    "removeTagMessage": "Remove \"{}\" from this profile?"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "New Operator Profile",
@@ -429,7 +431,9 @@
     "existingTagsTitle": "Existing Tags",
     "existingTagsDescription": "Edit the existing tags on this device. Add, remove, or modify any tag:",
     "existingOperator": "<Existing operator>",
-    "existingOperatorTags": "existing operator tags"
+    "existingOperatorTags": "existing operator tags",
+    "removeTagTitle": "Remove tag?",
+    "removeTagMessage": "Remove \"{}\" from this node?"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "Cannot change tile types while downloading offline areas",

--- a/lib/localizations/es.json
+++ b/lib/localizations/es.json
@@ -358,7 +358,9 @@
     "keyHint": "clave",
     "valueHint": "valor",
     "atLeastOneTagRequired": "Se requiere al menos una etiqueta",
-    "profileSaved": "Perfil \"{}\" guardado"
+    "profileSaved": "Perfil \"{}\" guardado",
+    "removeTagTitle": "¿Eliminar etiqueta?",
+    "removeTagMessage": "¿Eliminar \"{}\" de este perfil?"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "Nuevo Perfil de Operador",
@@ -429,7 +431,9 @@
     "existingTagsTitle": "Etiquetas Existentes",
     "existingTagsDescription": "Edite las etiquetas existentes en este dispositivo. Agregue, elimine o modifique cualquier etiqueta:",
     "existingOperator": "<Operador existente>",
-    "existingOperatorTags": "etiquetas de operador existentes"
+    "existingOperatorTags": "etiquetas de operador existentes",
+    "removeTagTitle": "¿Eliminar etiqueta?",
+    "removeTagMessage": "¿Eliminar \"{}\" de este nodo?"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "No se pueden cambiar los tipos de teselas mientras se descargan áreas sin conexión",

--- a/lib/localizations/fr.json
+++ b/lib/localizations/fr.json
@@ -358,7 +358,9 @@
     "keyHint": "clé",
     "valueHint": "valeur",
     "atLeastOneTagRequired": "Au moins une balise est requise",
-    "profileSaved": "Profil \"{}\" sauvegardé"
+    "profileSaved": "Profil \"{}\" sauvegardé",
+    "removeTagTitle": "Supprimer la balise ?",
+    "removeTagMessage": "Supprimer \"{}\" de ce profil ?"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "Nouveau Profil d'Opérateur",
@@ -429,7 +431,9 @@
     "existingTagsTitle": "Balises Existantes",
     "existingTagsDescription": "Modifiez les balises existantes sur cet appareil. Ajoutez, supprimez ou modifiez n'importe quelle balise :",
     "existingOperator": "<Opérateur existant>",
-    "existingOperatorTags": "balises d'opérateur existantes"
+    "existingOperatorTags": "balises d'opérateur existantes",
+    "removeTagTitle": "Supprimer la balise ?",
+    "removeTagMessage": "Supprimer \"{}\" de ce nœud ?"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "Impossible de changer les types de tuiles pendant le téléchargement des zones hors ligne",

--- a/lib/localizations/it.json
+++ b/lib/localizations/it.json
@@ -358,7 +358,9 @@
     "keyHint": "chiave",
     "valueHint": "valore",
     "atLeastOneTagRequired": "È richiesto almeno un tag",
-    "profileSaved": "Profilo \"{}\" salvato"
+    "profileSaved": "Profilo \"{}\" salvato",
+    "removeTagTitle": "Rimuovere tag?",
+    "removeTagMessage": "Rimuovere \"{}\" da questo profilo?"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "Nuovo Profilo Operatore",
@@ -429,7 +431,9 @@
     "existingTagsTitle": "Tag Esistenti",
     "existingTagsDescription": "Modifica i tag esistenti su questo dispositivo. Aggiungi, rimuovi o modifica qualsiasi tag:",
     "existingOperator": "<Operatore esistente>",
-    "existingOperatorTags": "tag operatore esistenti"
+    "existingOperatorTags": "tag operatore esistenti",
+    "removeTagTitle": "Rimuovere tag?",
+    "removeTagMessage": "Rimuovere \"{}\" da questo nodo?"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "Impossibile cambiare tipi di tile durante il download di aree offline",

--- a/lib/localizations/pt.json
+++ b/lib/localizations/pt.json
@@ -358,7 +358,9 @@
     "keyHint": "chave",
     "valueHint": "valor",
     "atLeastOneTagRequired": "Pelo menos uma tag é obrigatória",
-    "profileSaved": "Perfil \"{}\" salvo"
+    "profileSaved": "Perfil \"{}\" salvo",
+    "removeTagTitle": "Remover tag?",
+    "removeTagMessage": "Remover \"{}\" deste perfil?"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "Novo Perfil de Operador",
@@ -429,7 +431,9 @@
     "existingTagsTitle": "Tags Existentes",
     "existingTagsDescription": "Edite as tags existentes neste dispositivo. Adicione, remova ou modifique qualquer tag:",
     "existingOperator": "<Operador existente>",
-    "existingOperatorTags": "tags de operador existentes"
+    "existingOperatorTags": "tags de operador existentes",
+    "removeTagTitle": "Remover tag?",
+    "removeTagMessage": "Remover \"{}\" deste nó?"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "Não é possível alterar tipos de tiles durante o download de áreas offline",

--- a/lib/localizations/zh.json
+++ b/lib/localizations/zh.json
@@ -358,7 +358,9 @@
     "keyHint": "键",
     "valueHint": "值",
     "atLeastOneTagRequired": "至少需要一个标签",
-    "profileSaved": "配置文件 \"{}\" 已保存"
+    "profileSaved": "配置文件 \"{}\" 已保存",
+    "removeTagTitle": "删除标签？",
+    "removeTagMessage": "从此配置文件中删除 \"{}\"？"
   },
   "operatorProfileEditor": {
     "newOperatorProfile": "新建运营商配置文件",
@@ -429,7 +431,9 @@
     "existingTagsTitle": "现有标签",
     "existingTagsDescription": "编辑此设备上的现有标签。添加、删除或修改任何标签：",
     "existingOperator": "<现有运营商>",
-    "existingOperatorTags": "现有运营商标签"
+    "existingOperatorTags": "现有运营商标签",
+    "removeTagTitle": "删除标签？",
+    "removeTagMessage": "从此节点中删除 \"{}\"？"
   },
   "layerSelector": {
     "cannotChangeTileTypes": "在下载离线区域时无法更改瓦片类型",

--- a/lib/screens/operator_profile_editor.dart
+++ b/lib/screens/operator_profile_editor.dart
@@ -146,19 +146,20 @@ class _OperatorProfileEditorState extends State<OperatorProfileEditor> {
 
   void _confirmRemoveTag(int index) async {
     final tagKey = _tags[index].key;
+    final locService = LocalizationService.instance;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Remove tag?'),
-        content: Text('Remove "$tagKey" from this profile?'),
+        title: Text(locService.t('profileEditor.removeTagTitle')),
+        content: Text(locService.t('profileEditor.removeTagMessage', params: [tagKey])),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(LocalizationService.instance.t('common.cancel')),
+            child: Text(locService.cancel),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(LocalizationService.instance.t('common.delete')),
+            child: Text(locService.t('actions.delete')),
           ),
         ],
       ),

--- a/lib/screens/profile_editor.dart
+++ b/lib/screens/profile_editor.dart
@@ -201,19 +201,20 @@ class _ProfileEditorState extends State<ProfileEditor> {
 
   void _confirmRemoveTag(int index) async {
     final tagKey = _tags[index].key;
+    final locService = LocalizationService.instance;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Remove tag?'),
-        content: Text('Remove "$tagKey" from this profile?'),
+        title: Text(locService.t('profileEditor.removeTagTitle')),
+        content: Text(locService.t('profileEditor.removeTagMessage', params: [tagKey])),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(LocalizationService.instance.t('common.cancel')),
+            child: Text(locService.cancel),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(LocalizationService.instance.t('common.delete')),
+            child: Text(locService.t('actions.delete')),
           ),
         ],
       ),

--- a/lib/widgets/nsi_tag_value_field.dart
+++ b/lib/widgets/nsi_tag_value_field.dart
@@ -135,7 +135,7 @@ class _NSITagValueFieldState extends State<NSITagValueField> {
             widget.onChanged(value);
           },
           onSubmitted: (_) {
-            if (controller.text.isNotEmpty) {
+            if (controller.text.trim().isNotEmpty) {
               onFieldSubmitted();
             } else {
               widget.onCleared?.call();

--- a/lib/widgets/refine_tags_sheet.dart
+++ b/lib/widgets/refine_tags_sheet.dart
@@ -548,19 +548,20 @@ class _RefineTagsSheetState extends State<RefineTagsSheet> {
 
   void _confirmRemoveAdditionalTag(int index) async {
     final tagKey = _additionalExistingTags[index].key;
+    final locService = LocalizationService.instance;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Remove tag?'),
-        content: Text('Remove "$tagKey" from this node?'),
+        title: Text(locService.t('refineTagsSheet.removeTagTitle')),
+        content: Text(locService.t('refineTagsSheet.removeTagMessage', params: [tagKey])),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(LocalizationService.instance.t('common.cancel')),
+            child: Text(locService.cancel),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(LocalizationService.instance.t('common.delete')),
+            child: Text(locService.t('actions.delete')),
           ),
         ],
       ),

--- a/test/widgets/nsi_tag_value_field_test.dart
+++ b/test/widgets/nsi_tag_value_field_test.dart
@@ -38,7 +38,7 @@ void main() {
                 focusNode: focusNode,
                 onChanged: onChanged,
                 onSubmitted: (_) {
-                  if (controller.text.isNotEmpty) {
+                  if (controller.text.trim().isNotEmpty) {
                     onFieldSubmitted();
                   } else {
                     onCleared?.call();
@@ -153,6 +153,34 @@ void main() {
           reason: 'onCleared should not fire when field has text');
       expect(controller.text, equals('Axis'),
           reason: 'Should auto-complete partial text');
+    });
+
+    testWidgets('pressing Done on whitespace-only field calls onCleared',
+        (tester) async {
+      bool clearedCalled = false;
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(buildAutocompleteField(
+        controller: controller,
+        focusNode: focusNode,
+        suggestions: ['Axis', 'Dahua', 'Hikvision'],
+        onChanged: (_) {},
+        onSelected: (_) {},
+        onCleared: () => clearedCalled = true,
+      ));
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), '   ');
+      await tester.pump();
+
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(clearedCalled, isTrue,
+          reason: 'onCleared should fire when Done pressed on whitespace-only field');
     });
 
     testWidgets('onCleared not provided — Done on empty field is a no-op',


### PR DESCRIPTION
## Summary
- Follow-on to #104 — now that pressing Done on an empty tag value field no longer auto-selects the first suggestion, this PR wires up an `onCleared` callback to prompt the user to remove the tag entirely
- Adds `onCleared` callback to `NSITagValueField` — fires when Done is pressed on an empty field
- All three callers (profile editor, operator profile editor, refine tags sheet) show a "Remove tag?" confirmation dialog
- 4 widget tests verify the onSubmitted guard and onCleared callback behavior

## Changes
- **`lib/widgets/nsi_tag_value_field.dart`** — new `onCleared` callback, called from `onSubmitted` when text is empty
- **`lib/screens/profile_editor.dart`** — `_confirmRemoveTag()` dialog, wired to `onCleared`
- **`lib/screens/operator_profile_editor.dart`** — same pattern
- **`lib/widgets/refine_tags_sheet.dart`** — same pattern for additional existing tags
- **`test/widgets/nsi_tag_value_field_test.dart`** — 4 tests: empty field stays empty, onCleared fires, non-empty doesn't fire onCleared, no-op when onCleared not provided

## Test plan
- [x] 4 widget tests for onSubmitted guard and onCleared callback
- [ ] Manual: clear a tag value, press Done — "Remove tag?" dialog appears
- [ ] Manual: confirm removal — tag row is removed
- [ ] Manual: cancel removal — tag stays with empty value
- [ ] Manual: refinable tags (start empty by design) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)