### PR TITLE
Use generated Dart client for deflock-router API

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  deflock_router_client:
+    dependency: "direct main"
+    description:
+      path: "../FlockHopper/packages/deflock_router_client"
+      relative: true
+    source: path
+    version: "1.0.0"
   desktop_webview_window:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   package_info_plus: ^8.0.0
   csv: ^6.0.0
   collection: ^1.18.0
+  deflock_router_client:
+    path: ../FlockHopper/packages/deflock_router_client
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- Replace manual JSON construction and parsing in `routing_service.dart` with generated types from the deflock-router OpenAPI spec
- Add `deflock_router_client` as a path dependency pointing to `../FlockHopper/packages/deflock_router_client`

### What changed in routing_service.dart

- Request building: manual `Map` literals → `router.DirectionsRequest`, `router.Coordinate`, `router.NodeProfile` with `.toJson()`
- Response parsing: manual `data['result']['route']` map access → `router.DirectionsResult.fromJson()` + `router.RouteGeometry` fields
- Same HTTP transport, timeout handling, and error handling preserved

### Dependency

Requires [flockhopperdev/FlockHopper#1](https://github.com/flockhopperdev/FlockHopper/pull/1) to be merged first (provides the generated Dart client package).

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — all 41 tests pass (including 5 routing service tests)
- [x] Request body shape unchanged (verified via test that captures serialized body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)