### PR TITLE
Don't require trailing new line in build.keys.conf

### DIFF
--- a/do_builds.sh
+++ b/do_builds.sh
@@ -28,7 +28,7 @@ read_from_file() {
       echo "$v"
       return 0
     fi
-  done < "$file"
+  done < <(cat "$file"; echo)
   
   return 1
 }


### PR DESCRIPTION
## Description
Fixes an issue where the last line of `build_keys.conf` would be ignored if it did not end with a trailing newline character. This ensures that all configuration keys are loaded correctly regardless of the file's formatting.

tldr; i wasted an hour of my life trying to figure out why i was getting an error saying the clientid wasn't found when it was clearly in the file and I'd like others to avoid this issue 🙂 

## Problem
In `do_builds.sh`, the `read_from_file` function used a standard `while read` loop:

    bash done < "$file"

In Bash, the `read` command returns a non-zero exit code when it encounters the End of File (EOF). If the last line of the file does not have a newline character (`\n`) at the end, the loop terminates before processing that final line. 

This caused the following error even when the key was present:
`Error: OSM_SANDBOX_CLIENTID not found in build_keys.conf`

## Solution
I have updated the loop termination in `do_builds.sh` to:

    bash done < <(cat "$file"; echo)

**Changes:**
1. **Process Substitution `<(...)`**: Feeds the output of the command group into the loop. This avoids using a pipe (`|`), which would create a subshell and prevent the function from returning values correctly.
2. **Force Newline**: By running `cat "$file"; echo`, we ensure the data stream fed to the loop always ends with a newline. This makes the `read` command process the final line even if the physical file is missing the trailing newline.

## Verification
- **Before Fix**: Removing the newline at the end of `build_keys.conf` caused `OSM_SANDBOX_CLIENTID` to be "missing."
- **After Fix**: The script correctly identifies all keys regardless of whether the file ends with a character or a newline.