### PR TITLE
Update gps_controller to not require location accuracy in android.

### DIFF
--- a/lib/widgets/map/gps_controller.dart
+++ b/lib/widgets/map/gps_controller.dart
@@ -4,6 +4,9 @@ import 'package:flutter_map_animations/flutter_map_animations.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 
+import 'package:geolocator_android/geolocator_android.dart' show AndroidSettings;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+
 import '../../dev_config.dart';
 import '../../app_state.dart' show FollowMeMode;
 import '../../services/proximity_alert_service.dart';
@@ -145,15 +148,21 @@ class GpsController {
   void _startPositionStream() {
     final followMeMode = _getCurrentFollowMeMode?.call() ?? FollowMeMode.off;
     final distanceFilter = followMeMode == FollowMeMode.off ? 5 : 1; // 5m normal, 1m follow-me
-    
+
     debugPrint('[GpsController] Starting GPS position stream (${distanceFilter}m filter)');
-    
+
     try {
       _positionSub = Geolocator.getPositionStream(
-        locationSettings: LocationSettings(
-          accuracy: LocationAccuracy.high, // Request best, accept what we get
-          distanceFilter: distanceFilter,
-        ),
+        locationSettings: defaultTargetPlatform == TargetPlatform.android
+            ? AndroidSettings(
+                accuracy: LocationAccuracy.high,
+                distanceFilter: distanceFilter,
+                forceLocationManager: true,
+              )
+            : LocationSettings(
+                accuracy: LocationAccuracy.high,
+                distanceFilter: distanceFilter,
+              ),
       ).listen(
         _onPositionReceived,
         onError: _onPositionError,

--- a/lib/widgets/map/gps_controller.dart
+++ b/lib/widgets/map/gps_controller.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map_animations/flutter_map_animations.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
-
-import 'package:geolocator_android/geolocator_android.dart' show AndroidSettings;
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
 
 import '../../dev_config.dart';


### PR DESCRIPTION
**I have only tested this for Android. I do not know how to test for iOS**, however it seems like it should work.

I believe this would fix: https://github.com/FoggedLens/deflock-app/issues/149.

This updates the GpsController to explicitly use Android's native hardware Location Manager instead of the Fused Location Provider (FLP). This will prevent Google Services from attempting to handle the request and asking for location accuracy. This will require a full GPS lock to function and will take longer to get a location fix vs using Location Accuracy. I believe this to be a worthy trade off with this app, though.