### PR TITLE
Update iOS and iOS Simulator builds to disable Swift Package Manager

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,7 +95,9 @@ jobs:
           dart run flutter_native_splash:create
 
       - name: Build iOS simulator app
-        run: flutter build ios --debug --simulator
+        run: |
+          flutter config --no-enable-swift-package-manager
+          flutter build ios --debug --simulator
 
       - name: Zip Runner.app
         run: cd build/ios/iphonesimulator && zip -r "$GITHUB_WORKSPACE/Runner.app.zip" Runner.app

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -235,6 +235,7 @@ jobs:
 
       - name: Build iOS .ipa
         run: |
+          flutter config --no-enable-swift-package-manager
           flutter build ipa --release \
             --export-options-plist=ios/exportOptions.plist \
             --dart-define=OSM_PROD_CLIENTID='${{ secrets.OSM_PROD_CLIENTID }}' \


### PR DESCRIPTION
Swift Package Manager was enabled by default in Flutter 3.44.0, released 6/8/2026. This causes the current code base to not build iOS correctly. This will need to be fixed for the long term but in the meantime, disable the SPM so we can continue builds.


