### PR TITLE
out skel -> out ids

### DIFF
--- a/lib/services/overpass_service.dart
+++ b/lib/services/overpass_service.dart
@@ -130,7 +130,7 @@ out body;
   way(bn);
   rel(bn);
 );
-out skel;
+out ids;
 ''';
   }
 

--- a/test/services/overpass_service_test.dart
+++ b/test/services/overpass_service_test.dart
@@ -57,7 +57,7 @@ void main() {
   }
 
   group('query building', () {
-    test('uses out skel for way/relation pass, out body for node pass',
+    test('uses out ids for way/relation pass, out body for node pass',
         () async {
       stubOverpassResponse([]);
 
@@ -69,7 +69,7 @@ void main() {
 
       final query = (captured.last as Map<String, String>)['data']!;
       expect(query, contains('out body;'));
-      expect(query, contains('out skel;'));
+      expect(query, contains('out ids;'));
       expect(query, isNot(contains('out meta;')));
     });
 


### PR DESCRIPTION
lightens load on overpass server by only asking for IDs of ways/relations that reference returned nodes