### PR TITLE
Fixes 172: Sanitize tags when editing or creating a node

### DIFF
--- a/lib/services/uploader.dart
+++ b/lib/services/uploader.dart
@@ -104,7 +104,7 @@ class Uploader {
           // Create new node
           final mergedTags = p.getCombinedTags();
           final tagsXml = mergedTags.entries.map((e) =>
-            '<tag k="${e.key}" v="${e.value}"/>').join('\n            ');
+            '<tag k="${_sanitizeXmlText(e.key)}" v="${_sanitizeXmlText(e.value)}"/>').join('\n            ');
           final nodeXml = '''
         <osm>
           <node changeset="$changesetId" lat="${p.coord.latitude}" lon="${p.coord.longitude}">
@@ -141,7 +141,7 @@ class Uploader {
           // Update existing node with version
           final mergedTags = p.getCombinedTags();
           final tagsXml = mergedTags.entries.map((e) =>
-            '<tag k="${e.key}" v="${e.value}"/>').join('\n            ');
+            '<tag k="${_sanitizeXmlText(e.key)}" v="${_sanitizeXmlText(e.value)}"/>').join('\n            ');
           final nodeXml = '''
         <osm>
           <node changeset="$changesetId" id="${p.originalNodeId}" version="$currentVersion" lat="${p.coord.latitude}" lon="${p.coord.longitude}">
@@ -190,7 +190,7 @@ class Uploader {
           // Extract creates a new node with tags from the original node
           final mergedTags = p.getCombinedTags();
           final tagsXml = mergedTags.entries.map((e) =>
-            '<tag k="${e.key}" v="${e.value}"/>').join('\n            ');
+            '<tag k="${_sanitizeXmlText(e.key)}" v="${_sanitizeXmlText(e.value)}"/>').join('\n            ');
           final nodeXml = '''
         <osm>
           <node changeset="$changesetId" lat="${p.coord.latitude}" lon="${p.coord.longitude}">


### PR DESCRIPTION
Was able to replicate the error in #172. 
```
[UploadQueue] Node operation failed (attempt 4): Failed to modify node: HTTP 400 - Cannot parse valid node from xml string         <osm>
          <node changeset="185871008" id="12663617731" version="3" lat="37.36582032009576" lon="-122.07795191049095">
            <tag k="camera:mount" v="pole"/>
            <tag k="camera:type" v="fixed"/>
            <tag k="man_made" v="surveillance"/>
            <tag k="manufacturer" v="Flock Safety"/>
            <tag k="manufacturer:wikidata" v="Q108485435"/>
            <tag k="surveillance" v="public"/>
            <tag k="surveillance:type" v="ALPR"/>
            <tag k="surveillance:zone" v="traffic"/>
            <tag k="wikimedia_commons" v="File:ALPR Los Altos Grant & Covington.jpg"/>
            <tag k="operator" v="Los Altos Police Department"/>
            <tag k="operator:wikidata" v="Q120751721"/>
            <tag k="direction" v="180"/>
          </node>
        </osm>. Fatal error: xmlParseEntityRef: no name at :11.

```

XML sanitization was previously only applied to user comments. This PR applies sanitization to tags as well. The current profiles don't include &s or free form texts boxes where users can add them, but if the & is added from the web or a custom profile, the node will be uneditable from the app.

This fixes that problem.

3 scenarios tested using OSM Sandbox. All passed.
- Creating a new node with an "&" in a text box.
- Editing a node to add a text box with "&"
- Moving a node with a text box that has an "&"

