### PR TITLE
Load last map position. Fallback to default location.

### DIFF
--- a/lib/widgets/map/map_position_manager.dart
+++ b/lib/widgets/map/map_position_manager.dart
@@ -37,9 +37,13 @@ class MapPositionManager {
         debugPrint('[MapPositionManager] Loaded last map position: ${_initialLocation!.latitude}, ${_initialLocation!.longitude}, zoom: $_initialZoom');
       } else {
         debugPrint('[MapPositionManager] Invalid saved coordinates, using defaults');
+        _initialLocation = const LatLng(37.7749, -122.4194);
+        _initialZoom = 15.0;
       }
     } catch (e) {
       debugPrint('[MapPositionManager] Failed to load last map position: $e');
+      _initialLocation = const LatLng(37.7749, -122.4194);
+      _initialZoom = 15.0;
     }
   }
 


### PR DESCRIPTION
If we ever get into a state where default Lat and Lon are saved, we don't actually reset them when we identify them. We just log them as bad. This should set them as default so the user never sees an error.

Fixes #180.

In draft because I have not been able to replicate. App compiles fine but haven't been able to induce a failure state. A test/check at compile testing what happens with the function could also be implemented.

Also, haven't been able search to see if there's a default already stored in the app that we should be calling instead of being explicit about the default location.