### PR TITLE
fix(tiles): pause/cap tile retries when offline (#136)

### DIFF
--- a/lib/widgets/map/tile_layer_manager.dart
+++ b/lib/widgets/map/tile_layer_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -34,6 +35,14 @@ class TileLayerManager {
   /// when a tile loads successfully.
   Duration _retryDelay = const Duration(seconds: 2);
 
+  /// Whether the device is currently considered offline.
+  ///
+  /// Set to `true` when a tile load error indicates a network/DNS failure
+  /// (e.g. [SocketException] or "Failed host lookup").  While offline, retry
+  /// delays are capped at [_maxRetryDelay] to avoid log spam and excessive
+  /// retry attempts.  Reset to `false` when a tile loads successfully.
+  bool _offline = false;
+
   static const _minRetryDelay = Duration(seconds: 2);
   static const _maxRetryDelay = Duration(seconds: 60);
 
@@ -43,6 +52,10 @@ class TileLayerManager {
   /// Current retry delay (exposed for testing).
   @visibleForTesting
   Duration get retryDelay => _retryDelay;
+
+  /// Whether the device is currently considered offline (exposed for testing).
+  @visibleForTesting
+  bool get isOffline => _offline;
 
   /// Stream of reset events (exposed for testing).
   @visibleForTesting
@@ -138,6 +151,12 @@ class TileLayerManager {
   /// Skips retry for [TileLoadCancelledException] (tile scrolled off screen)
   /// and [TileNotAvailableOfflineException] (no cached data, retrying won't
   /// help without network).
+  ///
+  /// When the error indicates the device is offline (a [SocketException] or
+  /// an error message containing "Failed host lookup"), [_offline] is set to
+  /// `true` and the "scheduling retry" debug message is only printed once —
+  /// on the transition into offline — to avoid log spam.  While offline,
+  /// [scheduleRetry] uses [_maxRetryDelay] instead of the climbing backoff.
   @visibleForTesting
   void onTileLoadError(
     TileImage tile,
@@ -150,23 +169,41 @@ class TileLayerManager {
     // Offline misses won't resolve by retrying — tile isn't cached.
     if (error is TileNotAvailableOfflineException) return;
 
-    debugPrint(
-      '[TileLayerManager] Tile error at '
-      '${tile.coordinates.z}/${tile.coordinates.x}/${tile.coordinates.y}, '
-      'scheduling retry in ${_retryDelay.inSeconds}s',
-    );
+    final bool isOfflineError = _isOfflineError(error);
+
+    // Log once when entering offline; always for online errors (avoids spam).
+    if (!isOfflineError || !_offline) {
+      debugPrint(
+        '[TileLayerManager] Tile error at '
+        '${tile.coordinates.z}/${tile.coordinates.x}/${tile.coordinates.y}, '
+        'scheduling retry in ${_retryDelay.inSeconds}s',
+      );
+    }
+
+    if (isOfflineError) _offline = true;
     scheduleRetry();
   }
+
+  /// True when [error] indicates the device is offline (DNS/socket failure).
+  bool _isOfflineError(Object error) =>
+      error is SocketException ||
+      error.toString().contains('Failed host lookup');
+
 
   /// Schedule a debounced tile reset with exponential backoff.
   ///
   /// Cancels any pending retry timer and starts a new one at the current
   /// [_retryDelay].  After the timer fires, [_retryDelay] doubles (capped
   /// at [_maxRetryDelay]).
+  ///
+  /// When [_offline] is `true`, the timer is armed with [_maxRetryDelay]
+  /// (60s) instead of the climbing [_retryDelay], so offline retries are
+  /// infrequent and don't spam logs.
   @visibleForTesting
   void scheduleRetry() {
     _retryTimer?.cancel();
-    _retryTimer = Timer(_retryDelay, () {
+    final Duration delay = _offline ? _maxRetryDelay : _retryDelay;
+    _retryTimer = Timer(delay, () {
       if (!_resetController.isClosed) {
         debugPrint('[TileLayerManager] Firing tile reset to retry failed tiles');
         _resetController.add(null);
@@ -191,6 +228,7 @@ class TileLayerManager {
   /// flutter_map has already marked as `loadError`.
   void onTileLoadSuccess() {
     _retryDelay = _minRetryDelay;
+    _offline = false;
   }
 
   /// Build tile layer widget with current provider and type.

--- a/test/widgets/map/tile_layer_manager_test.dart
+++ b/test/widgets/map/tile_layer_manager_test.dart
@@ -615,4 +615,85 @@ void main() {
       });
     });
   });
+
+  group('TileLayerManager offline detection', () {
+    late TileLayerManager manager;
+    late MockTileImage mockTile;
+
+    setUp(() {
+      manager = TileLayerManager();
+      mockTile = MockTileImage();
+      when(() => mockTile.coordinates)
+          .thenReturn(const TileCoordinates(1, 2, 3));
+    });
+
+    tearDown(() {
+      manager.dispose();
+    });
+
+    test('starts online (isOffline is false)', () {
+      expect(manager.isOffline, isFalse);
+    });
+
+    test('a SocketException marks the manager offline', () {
+      manager.onTileLoadError(
+        mockTile,
+        const SocketException('Failed host lookup: tile.openstreetmap.org'),
+        null,
+      );
+      expect(manager.isOffline, isTrue);
+    });
+
+    test('a "Failed host lookup" message marks offline (non-SocketException)', () {
+      manager.onTileLoadError(
+        mockTile,
+        const HttpException('ClientException: Failed host lookup: host'),
+        null,
+      );
+      expect(manager.isOffline, isTrue);
+    });
+
+    test('an ordinary error leaves the manager online', () {
+      manager.onTileLoadError(
+        mockTile,
+        const HttpException('tile fetch failed'),
+        null,
+      );
+      expect(manager.isOffline, isFalse);
+    });
+
+    test('onTileLoadSuccess clears offline state', () {
+      manager.onTileLoadError(
+        mockTile,
+        const SocketException('Failed host lookup: x'),
+        null,
+      );
+      expect(manager.isOffline, isTrue);
+
+      manager.onTileLoadSuccess();
+      expect(manager.isOffline, isFalse);
+    });
+
+    test('while offline, retry is capped at 60s instead of the 2s backoff', () {
+      FakeAsync().run((async) {
+        final resets = <void>[];
+        manager.resetStream.listen((_) => resets.add(null));
+
+        manager.onTileLoadError(
+          mockTile,
+          const SocketException('Failed host lookup: x'),
+          null,
+        );
+
+        // Nothing fires at the normal 2s delay — offline caps it to 60s.
+        async.elapse(const Duration(seconds: 2));
+        expect(resets, isEmpty);
+
+        // Exactly one reset fires once the 60s offline cap elapses.
+        async.elapse(const Duration(seconds: 58));
+        expect(resets, hasLength(1));
+      });
+    });
+  });
+
 }


### PR DESCRIPTION
Fixes #136.

## Problem
When the device is fully offline (airplane mode, no signal), tile fetches throw `SocketException: Failed host lookup`. `TileLayerManager` treated these like transient errors: it kept the 2s→4s→…→60s backoff climbing and printed a "scheduling retry" line on every failed tile, spamming the log with DNS failures.

## Change
The app has no connectivity package, so offline is inferred from the error itself (no new dependency):

- `onTileLoadError` classifies an error as offline when it is a `SocketException` or its message contains `Failed host lookup`.
- While offline, `scheduleRetry` arms the timer at the existing `_maxRetryDelay` (60s) instead of the climbing delay, so retries stay infrequent.
- The "scheduling retry" log line is printed only once, on the transition into offline.
- Offline state clears on the next successful load (`onTileLoadSuccess`).

Existing behavior for transient (online) errors and the `TileLoadCancelledException` / `TileNotAvailableOfflineException` early-returns is unchanged.

## Tests
Adds a `TileLayerManager offline detection` group (mocktail + `FakeAsync`, matching the existing test style): the offline flag is set on a `SocketException` / "Failed host lookup", cleared on success, ordinary errors stay online, and the retry is capped at 60s rather than firing at 2s while offline. Full suite green (`flutter test`), `flutter analyze` clean.

## Open question for maintainers
Without a connectivity package, "offline" is inferred from the error type/message. If you'd prefer an explicit signal (e.g. `connectivity_plus`) or a different cap policy, happy to adjust.

Generated with Claude Code