### PR TITLE
Update Flock Raven tags with correct fields. Solves Issue #162

### DIFF
--- a/lib/models/node_profile.dart
+++ b/lib/models/node_profile.dart
@@ -195,10 +195,10 @@ class NodeProfile {
           name: 'Flock Raven',
           tags: const {
             'man_made': 'surveillance',
-            'surveillance': 'public',
+            'surveillance': 'outdoor',
             'surveillance:type': 'gunshot_detector',
-            'brand': 'Flock Safety',
-            'brand:wikidata': 'Q108485435',
+            'manufacturer': 'Flock Safety',
+            'manufacturer:wikidata': 'Q108485435',
           },
           builtin: true,
           requiresDirection: false,


### PR DESCRIPTION
"brand" needs to be changed to "manufacturer". 

See openstreetmaps official docs:
https://wiki.openstreetmap.org/wiki/Tag%3Asurveillance%3Atype%3Dgunshot_detector

PR to close out issue #162 